### PR TITLE
Exclude some parameters when validating signature

### DIFF
--- a/lib/Shopify/Api/Client.php
+++ b/lib/Shopify/Api/Client.php
@@ -112,6 +112,12 @@ class Client
         $calculated = array();
 
         foreach ($params as $key => $value) {
+            if ($key == 'signature') {
+                continue;
+            }
+            if ($key == 'admin' && $value == 1) {
+                continue;
+            }
             $calculated[] = $key . "=" . $value;
         }
 

--- a/tests/Shopify/Api/Tests/ClientTest.php
+++ b/tests/Shopify/Api/Tests/ClientTest.php
@@ -78,6 +78,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'shop' => "some-shop.myshopify.com",
             'code' => "a94a110d86d2452eb3e2af4cfb8a3828",
             'timestamp' => "1337178173", // 2012-05-16 14:22:53
+            'signature' => $signature,
+            'admin' => 1,
         );
 
         $this->assertEquals($signature, $this->api->generateSignature($params));


### PR DESCRIPTION
The signature and admin parameters need to be excluded when validating the signature (or the validation fails).
